### PR TITLE
fix ConvertTransaction

### DIFF
--- a/yellowstone_geyser/geyser.go
+++ b/yellowstone_geyser/geyser.go
@@ -346,6 +346,7 @@ func ConvertTransaction(geyserTx *yellowstone_geyser_pb.SubscribeUpdateTransacti
 				Writable: make([]solana.PublicKey, 0),
 			},
 		},
+		Slot: geyserTx.Slot,
 	}
 
 	tx.Meta.PreBalances = meta.PreBalances


### PR DESCRIPTION
fix some bugs in ConvertTransaction:
1. tx.Meta.InnerInstructions and tx.Meta.InnerInstructions[i[.Instructions: add append
2. tx.Meta.InnerInstructions[i].Instructions[x].Data: trans raw data to type Base58 and set it to Data
3. solCtx: use reflect to set solCtx to tx.Transaction.asParsedTransaction
4. bytesToUint16Slice: according to : https://github.com/gagliardetto/solana-go/blob/da2193071f56059aa35010a239cece016c4e827f/transaction.go#L134

These changes are just the result of my personal experiments, and they work well in my own projects. I can't guarantee that these changes will not introduce other bugs.
This pull request is just to provide a bug fix, you are free to reject it and use a better way to fix the bug.